### PR TITLE
feat: add alive check for channel, socket handler

### DIFF
--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -140,6 +140,11 @@ where
                 .transpose()?,
         })
     }
+
+    /// Returns whether the `Channel` half is still alive.
+    pub async fn alive(&self) -> bool {
+        !self.handler_tx.is_closed()
+    }
 }
 
 /// The status of a `Channel`.

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -98,6 +98,11 @@ where
     pub fn close(self) {
         let _ = self.handler_tx.send(HandlerSocketMessage::Close);
     }
+
+    /// Returns whether the `Socket` half is still alive.
+    pub async fn alive(&self) -> bool {
+        !self.handler_tx.is_closed()
+    }
 }
 
 /// A monotonically-increasing counter for tracking messages.


### PR DESCRIPTION
Adds an `alive()` function for `ChannelHandler` and `SocketHandler` that returns whether the corresponding task is still alive.